### PR TITLE
Destroy joints when vehicles are destroyed/detached

### DIFF
--- a/src/main/java/org/terasology/minecarts/components/joints/CartJointComponent.java
+++ b/src/main/java/org/terasology/minecarts/components/joints/CartJointComponent.java
@@ -101,4 +101,20 @@ public class CartJointComponent implements Component {
             applySocketImpulse(rearJointSocket, delta);
         }
     }
+
+    public void invalidateJoints() {
+        if (frontJointSocket != null) {
+            invalidateConnectingSocket(frontJointSocket);
+            frontJointSocket = null;
+        }
+        if (rearJointSocket != null) {
+            invalidateConnectingSocket(rearJointSocket);
+            rearJointSocket = null;
+        }
+    }
+
+    private void invalidateConnectingSocket(CartJointSocket socket) {
+        CartJointComponent connectingJoint = socket.connectingVehicle.getComponent(CartJointComponent.class);
+        connectingJoint.setJointSocketAt(null, socket.connectingSocketLocation);
+    }
 }

--- a/src/main/java/org/terasology/minecarts/controllers/CartJointSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartJointSystem.java
@@ -19,10 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.health.DestroyEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.minecarts.Constants;
 import org.terasology.minecarts.components.RailVehicleComponent;
@@ -31,6 +34,7 @@ import org.terasology.minecarts.components.joints.CartJointSocket;
 import org.terasology.minecarts.components.joints.CartJointSocketLocation;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
+import org.terasology.segmentedpaths.components.SegmentEntityComponent;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 @Share(CartJointSystem.class)
@@ -64,6 +68,12 @@ public class CartJointSystem extends BaseComponentSystem implements UpdateSubscr
                 joint.rearJointSocket.hasImpulseBeenApplied = false;
             }
         }
+    }
+
+    @ReceiveEvent(components = {RailVehicleComponent.class, CartJointComponent.class})
+    public void onVehicleDestroy(DestroyEvent event, EntityRef vehicle, CartJointComponent jointComponent) {
+        LOGGER.info("Destroying joints");
+        jointComponent.invalidateJoints();
     }
 
     private boolean isDesiredSocketUnoccupied(EntityRef vehicle,

--- a/src/main/java/org/terasology/minecarts/controllers/CartJointSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartJointSystem.java
@@ -82,7 +82,6 @@ public class CartJointSystem extends BaseComponentSystem implements UpdateSubscr
 
     @ReceiveEvent(components = {RailVehicleComponent.class, CartJointComponent.class})
     public void onVehicleDestroy(DestroyEvent event, EntityRef vehicle, CartJointComponent jointComponent) {
-        LOGGER.info("Destroying joints");
         jointComponent.invalidateJoints();
     }
 

--- a/src/main/java/org/terasology/minecarts/controllers/CartJointSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartJointSystem.java
@@ -70,6 +70,16 @@ public class CartJointSystem extends BaseComponentSystem implements UpdateSubscr
         }
     }
 
+    @ReceiveEvent(components = {SegmentEntityComponent.class})
+    public void beforeVehicleDetachFromRail(BeforeRemoveComponent event, EntityRef vehicle) {
+        if (!vehicle.hasComponent(CartJointComponent.class)) {
+            return;
+        }
+
+        CartJointComponent jointComponent = vehicle.getComponent(CartJointComponent.class);
+        jointComponent.invalidateJoints();
+    }
+
     @ReceiveEvent(components = {RailVehicleComponent.class, CartJointComponent.class})
     public void onVehicleDestroy(DestroyEvent event, EntityRef vehicle, CartJointComponent jointComponent) {
         LOGGER.info("Destroying joints");


### PR DESCRIPTION
Destroys (invalidates) joints to and from a vehicle, if any, when it is destroyed/detached from the rails.

## Testing
Create a cart chain by joining them together using the wrench. Destroy one by using the pickaxe or push a cart beyond a rail segment such that it is detached from it. The joints, if any, it has are destroyed.

## Todo
- [x] Invalidate joints on vehicle destroy
- [x] Invalidate joints on vehicle detach from rails