### PR TITLE
Custom friction coefficients for rails

### DIFF
--- a/src/main/java/org/terasology/minecarts/Constants.java
+++ b/src/main/java/org/terasology/minecarts/Constants.java
@@ -20,7 +20,6 @@ package org.terasology.minecarts;
  */
 public class Constants {
     public static final float GRAVITY = 9.8f;
-    public static final float FRICTION_COFF = .1f;
     public static final float BAUMGARTE_COFF = .1f;
     public static final float VELOCITY_CAP = 15f;
     public static final float PLAYER_MASS = 30f;

--- a/src/main/java/org/terasology/minecarts/blocks/RailComponent.java
+++ b/src/main/java/org/terasology/minecarts/blocks/RailComponent.java
@@ -21,4 +21,5 @@ import org.terasology.world.block.ForceBlockActive;
 
 @ForceBlockActive
 public class RailComponent implements Component {
+    public float frictionCoefficient = 0.1f;
 }

--- a/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
@@ -150,7 +150,8 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
                 railVehicleComponent.velocity.add(tangent.project(gravity));
 
                 //apply some friction based off the gravity vector projected on the normal multiplied against a friction coff
-                Vector3f friction = normal.project(gravity).invert().mul(Constants.FRICTION_COFF);
+                RailComponent rail = segmentVehicleComponent.segmentEntity.getComponent(RailComponent.class);
+                Vector3f friction = normal.project(gravity).invert().mul(rail.frictionCoefficient);
 
                 float mag = railVehicleComponent.velocity.length() - friction.length();
                 //make sure the magnitude is not less then zero when the friction value is subtracted off of the velocity


### PR DESCRIPTION
Closes #20.

Adds a new property `frictionCoefficient` to `RailComponent` with a default value of `0.1` which can be used to specify custom friction coefficients for different rail types. This property is used by `CartMotionSystem` to calculate the friction to be applied on a cart depending on the value of the friction coefficient of the `RailComponent` on which the cart currently is.

## Testing
Change the default value of `frictionCoefficient` (or use a different type of rail with a different friction coefficient, your own or one from AdditionalRails) and notice a difference in the amount of friction force applied on a cart.