### PR TITLE
rename PathFollowerCmpt, 3-entity carts (two axis/axle)

### DIFF
--- a/src/main/java/org/terasology/minecarts/blocks/RailBlockSegmentMapper.java
+++ b/src/main/java/org/terasology/minecarts/blocks/RailBlockSegmentMapper.java
@@ -26,7 +26,7 @@ import org.terasology.segmentedpaths.Segment;
 import org.terasology.segmentedpaths.blocks.PathFamily;
 import org.terasology.segmentedpaths.components.BlockMappingComponent;
 import org.terasology.segmentedpaths.components.PathDescriptorComponent;
-import org.terasology.segmentedpaths.components.SegmentEntityComponent;
+import org.terasology.segmentedpaths.components.PathFollowerComponent;
 import org.terasology.segmentedpaths.controllers.SegmentCacheSystem;
 import org.terasology.segmentedpaths.controllers.SegmentMapping;
 import org.terasology.segmentedpaths.controllers.SegmentSystem;
@@ -51,7 +51,7 @@ public class RailBlockSegmentMapper implements SegmentMapping {
 
 
     @Override
-    public SegmentPair nextSegment(SegmentEntityComponent vehicle, SegmentEnd ends) {
+    public SegmentPair nextSegment(PathFollowerComponent vehicle, SegmentEnd ends) {
         BlockComponent blockComponent = vehicle.segmentEntity.getComponent(BlockComponent.class);
         if(vehicle.segmentEntity.hasComponent(BlockComponent.class)) {
             BlockFamily blockFamily = blockComponent.getBlock().getBlockFamily();

--- a/src/main/java/org/terasology/minecarts/components/RailVehicleComponent.java
+++ b/src/main/java/org/terasology/minecarts/components/RailVehicleComponent.java
@@ -17,6 +17,7 @@ package org.terasology.minecarts.components;
 
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.FieldReplicateType;
 import org.terasology.network.Replicate;
@@ -25,5 +26,9 @@ import org.terasology.network.ServerEvent;
 @ServerEvent(lagCompensate = true)
 public class RailVehicleComponent implements Component {
     @Replicate(FieldReplicateType.SERVER_TO_CLIENT)
-    public  Vector3f velocity = new Vector3f();
+    public Vector3f velocity = new Vector3f();
+
+    public float axleSpacing = 0.8f;
+    public EntityRef rearAxle;
+    public EntityRef frontAxle;
 }

--- a/src/main/java/org/terasology/minecarts/controllers/CartImpulseSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartImpulseSystem.java
@@ -35,7 +35,7 @@ import org.terasology.minecarts.components.RailVehicleComponent;
 import org.terasology.physics.components.RigidBodyComponent;
 import org.terasology.physics.events.CollideEvent;
 import org.terasology.registry.In;
-import org.terasology.segmentedpaths.components.SegmentEntityComponent;
+import org.terasology.segmentedpaths.components.PathFollowerComponent;
 import org.terasology.segmentedpaths.controllers.SegmentSystem;
 
 /**
@@ -67,7 +67,7 @@ public class CartImpulseSystem extends BaseComponentSystem implements UpdateSubs
     }
 
 
-    @ReceiveEvent(components = {RailVehicleComponent.class, SegmentEntityComponent.class, LocationComponent.class, RigidBodyComponent.class}, priority = EventPriority.PRIORITY_HIGH)
+    @ReceiveEvent(components = {RailVehicleComponent.class, PathFollowerComponent.class, LocationComponent.class, RigidBodyComponent.class}, priority = EventPriority.PRIORITY_HIGH)
     public void onBump(CollideEvent event, EntityRef entity) {
         CollisionFilterComponent collisionFilterComponent = entity.getComponent(CollisionFilterComponent.class);
         if (collisionFilterComponent != null && collisionFilterComponent.filter.contains(event.getOtherEntity()))
@@ -75,7 +75,7 @@ public class CartImpulseSystem extends BaseComponentSystem implements UpdateSubs
 
         if (event.getOtherEntity().hasComponent(CharacterComponent.class)) {
             handleCharacterCollision(event, entity);
-        } else if (event.getOtherEntity().hasComponent(RailVehicleComponent.class) && event.getOtherEntity().hasComponent(SegmentEntityComponent.class)) {
+        } else if (event.getOtherEntity().hasComponent(RailVehicleComponent.class) && event.getOtherEntity().hasComponent(PathFollowerComponent.class)) {
             this.handleCartCollision(event, entity);
         }
     }

--- a/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
@@ -43,7 +43,7 @@ import org.terasology.registry.In;
 import org.terasology.rendering.logic.MeshComponent;
 import org.terasology.segmentedpaths.Segment;
 import org.terasology.segmentedpaths.components.PathDescriptorComponent;
-import org.terasology.segmentedpaths.components.SegmentEntityComponent;
+import org.terasology.segmentedpaths.components.PathFollowerComponent;
 import org.terasology.segmentedpaths.controllers.SegmentCacheSystem;
 import org.terasology.segmentedpaths.controllers.SegmentSystem;
 import org.terasology.world.BlockEntityRegistry;
@@ -92,9 +92,9 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
     }
 
     public Vector3f updateHeading(EntityRef railVehcile,Vector3f oldHeading){
-        SegmentEntityComponent segmentEntityComponent = railVehcile.getComponent(SegmentEntityComponent.class);
-        if(segmentEntityComponent != null){
-            return segmentEntityComponent.heading.project(oldHeading).normalize();
+        PathFollowerComponent pathFollowerComponent = railVehcile.getComponent(PathFollowerComponent.class);
+        if(pathFollowerComponent != null){
+            return pathFollowerComponent.heading.project(oldHeading).normalize();
         }
         return null;
     }
@@ -104,7 +104,7 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
         LocationComponent location = railVehicle.getComponent(LocationComponent.class);
         RigidBodyComponent rigidBodyComponent = railVehicle.getComponent(RigidBodyComponent.class);
         RailVehicleComponent railVehicleComponent = railVehicle.getComponent(RailVehicleComponent.class);
-        SegmentEntityComponent segmentVehicleComponent = railVehicle.getComponent(SegmentEntityComponent.class);
+        PathFollowerComponent segmentVehicleComponent = railVehicle.getComponent(PathFollowerComponent.class);
 
         if (segmentVehicleComponent == null) {
             //checks to see if the cart hits a rail segment
@@ -116,7 +116,7 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
 
             //attach cart to rail segment
             if (ref.hasComponent(RailComponent.class)) {
-                segmentVehicleComponent = new SegmentEntityComponent();
+                segmentVehicleComponent = new PathFollowerComponent();
                 segmentVehicleComponent.segmentEntity = ref;
 
                 Prefab prefab = ref.getComponent(PathDescriptorComponent.class).descriptors.get(0);
@@ -124,7 +124,7 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
 
                 Vector3f position = segmentSystem.segmentPosition(ref);
                 Quat4f rotation = segmentSystem.segmentRotation(ref);
-                segmentVehicleComponent.t = segment.nearestT(location.getWorldPosition(), position, rotation);
+                segmentVehicleComponent.segmentPosition = segment.nearestT(location.getWorldPosition(), position, rotation);
                 segmentVehicleComponent.descriptor = prefab;
                 railVehicle.addComponent(segmentVehicleComponent);
                 segmentVehicleComponent.heading = segmentSystem.vehicleTangent(railVehicle);
@@ -190,9 +190,9 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
         RigidBodyComponent rigidBodyComponent = vehicle.getComponent(RigidBodyComponent.class);
         RailVehicleComponent railVehicleComponent = vehicle.getComponent(RailVehicleComponent.class);
 
-        //change the rigidbody into a non kinematic body and remove the SegmentEntityComponent
+        //change the rigidbody into a non kinematic body and remove the PathFollowerComponent
         rigidBodyComponent.kinematic = false;
-        vehicle.removeComponent(SegmentEntityComponent.class);
+        vehicle.removeComponent(PathFollowerComponent.class);
         rigidBodyComponent.velocity = new Vector3f(railVehicleComponent.velocity);
         rigidBodyComponent.collidesWith.add(StandardCollisionGroup.WORLD);
 

--- a/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
@@ -18,6 +18,7 @@ package org.terasology.minecarts.controllers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
@@ -91,9 +92,9 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
         }
     }
 
-    public Vector3f updateHeading(EntityRef railVehcile,Vector3f oldHeading){
-        PathFollowerComponent pathFollowerComponent = railVehcile.getComponent(PathFollowerComponent.class);
-        if(pathFollowerComponent != null){
+    public Vector3f updateHeading(EntityRef railVehicle, Vector3f oldHeading) {
+        PathFollowerComponent pathFollowerComponent = railVehicle.getComponent(PathFollowerComponent.class);
+        if (pathFollowerComponent != null) {
             return pathFollowerComponent.heading.project(oldHeading).normalize();
         }
         return null;
@@ -104,73 +105,98 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
         LocationComponent location = railVehicle.getComponent(LocationComponent.class);
         RigidBodyComponent rigidBodyComponent = railVehicle.getComponent(RigidBodyComponent.class);
         RailVehicleComponent railVehicleComponent = railVehicle.getComponent(RailVehicleComponent.class);
-        PathFollowerComponent segmentVehicleComponent = railVehicle.getComponent(PathFollowerComponent.class);
 
-        if (segmentVehicleComponent == null) {
-            //checks to see if the cart hits a rail segment
+        if (railVehicleComponent.rearAxle == null) {
+            railVehicleComponent.rearAxle = entityManager.create();
+        }
+
+        if (railVehicleComponent.frontAxle == null) {
+            railVehicleComponent.frontAxle = entityManager.create();
+        }
+
+        PathFollowerComponent rearPathFollowerComponent = railVehicleComponent.rearAxle.getComponent(PathFollowerComponent.class);
+        PathFollowerComponent frontPathFollowerComponent = railVehicleComponent.frontAxle.getComponent(PathFollowerComponent.class);
+
+        if (rearPathFollowerComponent == null || frontPathFollowerComponent == null) {
+            // Check to see if the cart hits a rail segment
             HitResult hit = physics.rayTrace(location.getWorldPosition(), Vector3f.down(), 1.2f, StandardCollisionGroup.DEFAULT, StandardCollisionGroup.WORLD);
-            if (hit == null || hit.getBlockPosition() == null)
+            if (hit == null || hit.getBlockPosition() == null) {
                 return;
+            }
 
             EntityRef ref = blockEntityRegistry.getBlockEntityAt(hit.getBlockPosition());
 
-            //attach cart to rail segment
+            // Attach cart to rail segment
             if (ref.hasComponent(RailComponent.class)) {
-                segmentVehicleComponent = new PathFollowerComponent();
-                segmentVehicleComponent.segmentEntity = ref;
+                rearPathFollowerComponent = new PathFollowerComponent();
+                rearPathFollowerComponent.segmentEntity = ref;
+                frontPathFollowerComponent = new PathFollowerComponent();
+                frontPathFollowerComponent.segmentEntity = ref;
 
                 Prefab prefab = ref.getComponent(PathDescriptorComponent.class).descriptors.get(0);
                 Segment segment = segmentCacheSystem.getSegment(prefab);
 
                 Vector3f position = segmentSystem.segmentPosition(ref);
                 Quat4f rotation = segmentSystem.segmentRotation(ref);
-                segmentVehicleComponent.segmentPosition = segment.nearestT(location.getWorldPosition(), position, rotation);
-                segmentVehicleComponent.descriptor = prefab;
-                railVehicle.addComponent(segmentVehicleComponent);
-                segmentVehicleComponent.heading = segmentSystem.vehicleTangent(railVehicle);
+                float nearestT = segment.nearestSegmentPosition(location.getWorldPosition(), position, rotation);
+                rearPathFollowerComponent.segmentPosition = nearestT - railVehicleComponent.axleSpacing / 2;
+                rearPathFollowerComponent.descriptor = prefab;
+                railVehicleComponent.rearAxle.addComponent(rearPathFollowerComponent);
+                rearPathFollowerComponent.heading = segmentSystem.vehicleTangent(railVehicleComponent.rearAxle);
+                frontPathFollowerComponent.segmentPosition = nearestT + railVehicleComponent.axleSpacing / 2;
+                frontPathFollowerComponent.descriptor = prefab;
+                railVehicleComponent.frontAxle.addComponent(frontPathFollowerComponent);
+                frontPathFollowerComponent.heading = segmentSystem.vehicleTangent(railVehicleComponent.frontAxle);
                 rigidBodyComponent.collidesWith.remove(StandardCollisionGroup.WORLD);
 
-                railVehicleComponent.velocity = segmentVehicleComponent.heading.project(rigidBodyComponent.velocity);
+                railVehicleComponent.velocity = rearPathFollowerComponent.heading.project(rigidBodyComponent.velocity);
 
-                railVehicle.addOrSaveComponent(segmentVehicleComponent);
+                railVehicleComponent.rearAxle.addOrSaveComponent(rearPathFollowerComponent);
+                railVehicleComponent.frontAxle.addOrSaveComponent(frontPathFollowerComponent);
             }
         } else {
-            if (railVehicleComponent.velocity.length() > Constants.VELOCITY_CAP)
+            if (railVehicleComponent.velocity.length() > Constants.VELOCITY_CAP) {
                 railVehicleComponent.velocity.normalize().mul(Constants.VELOCITY_CAP);
+            }
 
-            if (segmentSystem.isvehicleValid(railVehicle)) {
-                Vector3f position = segmentSystem.vehiclePoint(railVehicle);
+            if (segmentSystem.isVehicleValid(railVehicleComponent.rearAxle)
+                    && segmentSystem.isVehicleValid(railVehicleComponent.frontAxle)) {
+                Vector3f rearAxlePosition = segmentSystem.vehiclePoint(railVehicleComponent.rearAxle, 0f);
+                Vector3f frontAxlePosition = segmentSystem.vehiclePoint(railVehicleComponent.frontAxle, 0f);
                 MeshComponent mesh = railVehicle.getComponent(MeshComponent.class);
-                position.y = mesh.mesh.getAABB().getMax().y / 2.0f + position.y + .01f;
+                rearAxlePosition.y += mesh.mesh.getAABB().getMax().y / 2.0f + .01f;
+                frontAxlePosition.y += mesh.mesh.getAABB().getMax().y / 2.0f + .01f;
 
-                Vector3f normal = segmentSystem.vehicleNormal(railVehicle);
-                Vector3f tangent = segmentSystem.vehicleTangent(railVehicle);
+                Vector3f normal = segmentSystem.vehicleNormal(railVehicleComponent.rearAxle);
+                Vector3f tangent = segmentSystem.vehicleTangent(railVehicleComponent.rearAxle);
 
                 Vector3f gravity = Vector3f.down().mul(Constants.GRAVITY).mul(delta);
                 railVehicleComponent.velocity.add(tangent.project(gravity));
 
-                //apply some friction based off the gravity vector projected on the normal multiplied against a friction coff
+                // Apply friction based off the gravity vector projected on the normal multiplied against a friction coeff.
                 Vector3f friction = normal.project(gravity).invert().mul(Constants.FRICTION_COFF);
 
                 float mag = railVehicleComponent.velocity.length() - friction.length();
-                //make sure the magnitude is not less then zero when the friction value is subtracted off of the velocity
-                if (mag < 0)
+                // Ensure magnitude is not less than zero when the friction value is subtracted off of the velocity
+                if (mag < 0) {
                     mag = railVehicleComponent.velocity.length();
+                }
 
                 //apply the new velocity to the rail component
-                railVehicleComponent.velocity = segmentVehicleComponent.heading.project(railVehicleComponent.velocity).normalize().mul(mag);
+                railVehicleComponent.velocity = rearPathFollowerComponent.heading.project(railVehicleComponent.velocity).normalize().mul(mag);
 
                 //make sure the value is not nan or infinite
                 //occurs when the cart hits a perpendicular segment.
                 Util.bound(railVehicleComponent.velocity);
-                if (segmentSystem.move(railVehicle, Math.signum(segmentVehicleComponent.heading.dot(railVehicleComponent.velocity)) * mag * delta, segmentMapping)) {
+                if (segmentSystem.move(railVehicle, railVehicleComponent.rearAxle, Math.signum(rearPathFollowerComponent.heading.dot(railVehicleComponent.velocity)) * mag * delta, segmentMapping)
+                        && segmentSystem.move(railVehicle, railVehicleComponent.frontAxle, Math.signum(frontPathFollowerComponent.heading.dot(railVehicleComponent.velocity)) * mag * delta, segmentMapping)) {
 
                     //calculate the cart rotation
-                    Quat4f horizontalRotation = Quat4f.shortestArcQuat(Vector3f.north(), new Vector3f(segmentVehicleComponent.heading).setY(0).normalize());
-                    Quat4f verticalRotation = Quat4f.shortestArcQuat(new Vector3f(segmentVehicleComponent.heading).setY(0).normalize(), new Vector3f(segmentVehicleComponent.heading));
+                    Quat4f horizontalRotation = Quat4f.shortestArcQuat(Vector3f.north(), new Vector3f(frontAxlePosition).sub(rearAxlePosition).setY(0).normalize());
+                    Quat4f verticalRotation = Quat4f.shortestArcQuat(new Vector3f(rearPathFollowerComponent.heading).setY(0).normalize(), new Vector3f(rearPathFollowerComponent.heading));
                     verticalRotation.mul(horizontalRotation);
                     location.setLocalRotation(verticalRotation);
-                    location.setWorldPosition(position);
+                    location.setWorldPosition((rearAxlePosition.add(frontAxlePosition)).div(2));
                     rigidBodyComponent.kinematic = true;
                 } else {
                     detachFromRail(railVehicle);
@@ -192,7 +218,8 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
 
         //change the rigidbody into a non kinematic body and remove the PathFollowerComponent
         rigidBodyComponent.kinematic = false;
-        vehicle.removeComponent(PathFollowerComponent.class);
+        railVehicleComponent.rearAxle.removeComponent(PathFollowerComponent.class);
+        railVehicleComponent.frontAxle.removeComponent(PathFollowerComponent.class);
         rigidBodyComponent.velocity = new Vector3f(railVehicleComponent.velocity);
         rigidBodyComponent.collidesWith.add(StandardCollisionGroup.WORLD);
 


### PR DESCRIPTION
Renamed ambiguous `SegmentEntityCmpt`. to `PathFollowerCmpt`. Also renamed ambiguous variable names. (`t` -> `segmentPosition`)