### PR TITLE
fix: `ModuleTestingEnvironment` dependency

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -10,7 +10,7 @@
         { "id": "Drops", "minVersion": "1.0.1" },
         { "id": "Health", "minVersion": "1.0.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0" },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional": true },
         { "id": "SegmentedPaths", "minVersion": "1.0.0" }
     ],
     "isAsset": true,

--- a/module.txt
+++ b/module.txt
@@ -10,7 +10,7 @@
         { "id": "Drops", "minVersion": "1.0.1" },
         { "id": "Health", "minVersion": "1.0.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.1.0" },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0" },
         { "id": "SegmentedPaths", "minVersion": "1.0.0" }
     ],
     "isAsset": true,


### PR DESCRIPTION
- pre-release minor versions seem to be treated like real-release major versions wrt inclusion/exclusion