### PR TITLE
feat: add rigidbody collision support for cart to cart-rigid

### DIFF
--- a/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
+++ b/src/main/java/org/terasology/minecarts/controllers/CartMotionSystem.java
@@ -51,13 +51,7 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
     @In
     EntityManager entityManager;
     @In
-    WorldProvider worldProvider;
-    @In
     Physics physics;
-    @In
-    LocalPlayer localPlayer;
-    @In
-    InventoryManager inventoryManager;
     @In
     BlockEntityRegistry blockEntityRegistry;
     @In
@@ -171,7 +165,7 @@ public class CartMotionSystem extends BaseComponentSystem implements UpdateSubsc
                         Math.signum(segmentVehicleComponent.heading.dot(railVehicleComponent.velocity)) * mag * delta
                         , segmentMapping)) {
 
-                    if(railVehicleComponent.backAxisOffset == 0.0f && railVehicleComponent.frontAxisOffset == 0.0f) {
+                    if (railVehicleComponent.backAxisOffset == 0.0f && railVehicleComponent.frontAxisOffset == 0.0f) {
                         location.setWorldRotation(Util.rotation(segmentVehicleComponent.heading));
                         location.setWorldPosition(position);
                     } else {


### PR DESCRIPTION
This allow pushing rigidbody at the edge of the edge of rails where half the cart is off the rail and the second cart is transitioned to a rigidbody when it leaves the rail.  

The rigidbody gets out of sync with the ghost trigger so pushing a cart will have the trigger fixed in one location while the rigidbody is still getting pushed by the second cart. 

PR: https://github.com/MovingBlocks/Terasology/pull/4577
