### PR TITLE
chore: make `CoreAssets` dependency optional

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -8,7 +8,8 @@
     "dependencies": [
         {
             "id": "CoreAssets",
-            "minVersion": "2.0.1"
+            "minVersion": "2.0.1",
+            "optional": true
         },
         {
             "id": "Drops",


### PR DESCRIPTION
this PR fixes https://github.com/Terasology/Rails/issues/53 and  makes `CoreAssets` dependency optional